### PR TITLE
fix(func): fix error returns from function evaluables

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -221,10 +221,9 @@ func (*Parser) callEvaluable(fullname string, fun Evaluable, args ...Evaluable) 
 			}
 			r = r[0 : len(r)-1]
 		}
-
 		switch len(r) {
 		case 0:
-			return err, nil
+			return nil, err
 		case 1:
 			return r[0], err
 		default:

--- a/gval_parameterized_test.go
+++ b/gval_parameterized_test.go
@@ -387,6 +387,22 @@ func TestParameterized(t *testing.T) {
 			},
 			{
 
+				name:       "single-return function returns error",
+				expression: "Test(`dummy`)",
+				parameter:  map[string]interface{}{"Test": func(err string) error { return fmt.Errorf(err) }},
+				wantErr:    "dummy",
+				want:       "",
+			},
+			{
+
+				name:       "two-returns function returns an error",
+				expression: "Test(`dummy`)",
+				parameter:  map[string]interface{}{"Test": func(err string) (string, error) { return "ok", fmt.Errorf(err) }},
+				want:       "",
+				wantErr:    "dummy",
+			},
+			{
+
 				name:       "Simple parameter call from pointer",
 				expression: "fooptr.String",
 				parameter:  map[string]interface{}{"fooptr": &foo},


### PR DESCRIPTION
fixes problem with incoherent error returns from functions with single
(error) return value (sample signature: Test() error)
- currently this kind of function evaluates to the error string but
the actual error does not bubble up to Eval function
- after the change the error is returned by the Eval function which is
coherent with behavior for functions having more than one return value